### PR TITLE
jupyter-server-proxy 3.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,15 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # jupyterlab is missing on s390x.
+  skip: True  # [py<36 or (linux and s390x)]
   script: {{ PYTHON }} -m pip install --no-deps -vv --install-option="--skip-npm" .
 
 requirements:
   host:
     - python
-    - jupyter-packaging >=0.7,<1.0
-    - jupyterlab >=3.0,<4
+    - jupyter-packaging 0.12.0
+    - jupyterlab 3.4.4
     - pip
     - setuptools
     - wheel
@@ -38,12 +39,12 @@ test:
     # print everything
     - jupyter labextension list
     - jupyter server extension list
-    - jupyter serverextension list  # [not (linux and s390x)]
+    - jupyter serverextension list
     # validate each
     - jupyter server extension list 1>server_extensions 2>&1
     - cat server_extensions | grep -ie "jupyter_server_proxy.*OK"
-    - jupyter serverextension list 1>serverextensions 2>&1  # [not (linux and s390x)]
-    - cat serverextensions | grep -ie "jupyter_server_proxy.*OK"  # [not (linux and s390x)]
+    - jupyter serverextension list 1>serverextensions 2>&1
+    - cat serverextensions | grep -ie "jupyter_server_proxy.*OK"
     - jupyter labextension list 1>labextensions 2>&1
     - cat labextensions | grep -ie "@jupyterlab/server-proxy.*{{ version.replace(".", "\\.") }}.*OK"
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ test:
     # print everything
     - jupyter labextension list
     - jupyter server extension list
-    - jupyter serverextension list
+    - jupyter serverextension list  # [not (linux and s390x)]
     # validate each
     - jupyter server extension list 1>server_extensions 2>&1
     - cat server_extensions | grep -ie "jupyter_server_proxy.*OK"
-    - jupyter serverextension list 1>serverextensions 2>&1
-    - cat serverextensions | grep -ie "jupyter_server_proxy.*OK"
+    - jupyter serverextension list 1>serverextensions 2>&1  # [not (linux and s390x)]
+    - cat serverextensions | grep -ie "jupyter_server_proxy.*OK"  # [not (linux and s390x)]
     - jupyter labextension list 1>labextensions 2>&1
     - cat labextensions | grep -ie "@jupyterlab/server-proxy.*{{ version.replace(".", "\\.") }}.*OK"
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,31 @@
+{% set name = 'jupyter-server-proxy' %}
 {% set version = "3.2.2" %}
 
 package:
-  name: jupyter-server-proxy
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyter-server-proxy/jupyter-server-proxy-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{ name }}-{{ version }}.tar.gz
   sha256: 54690ea9467035d187c930c599e76065017baf16e118e6eebae0d3a008c4d946
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install --no-deps -vv --install-option="--skip-npm" .
 
 requirements:
   host:
-    - jupyter-packaging >=0.7,<0.8
+    - python
+    - jupyter-packaging >=0.7,<1.0
     - jupyterlab >=3.0,<4
     - pip
-    - python >=3.6
     - setuptools
+    - wheel
   run:
+    - python
     - aiohttp
     - jupyter_server >=1
-    - python >=3.6
     - simpervisor >=0.4
 
 test:
@@ -50,6 +52,7 @@ test:
 about:
   home: https://github.com/jupyterhub/jupyter-server-proxy
   license: BSD-3-Clause
+  license_family: BSD
   license_file:
     - LICENSE
     - jupyter_server_proxy/labextension/static/third-party-licenses.json

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 54690ea9467035d187c930c599e76065017baf16e118e6eebae0d3a008c4d946
 
 build:


### PR DESCRIPTION
Changelog: https://jupyter-server-proxy.readthedocs.io/en/latest/changelog.html
License: https://github.com/jupyterhub/jupyter-server-proxy/blob/v3.2.2/LICENSE
Requirements:
- https://github.com/jupyterhub/jupyter-server-proxy/blame/v3.2.2/pyproject.toml
- https://github.com/jupyterhub/jupyter-server-proxy/blob/v3.2.2/setup.py

Actions:
1. Remove noarch
2. Skip py<36
3. Add jinja2 template variable `name`
4. Fix python pinnings
5. Fix jupyter-packaging pinning because the upstream pyproject.toml was created on 16 Feb 2021 and after that date jupyter-packaging released new versions, they are compatible until <1.0
6. Add wheel to host
7. Add license_family